### PR TITLE
Feature/remove caught exceptions

### DIFF
--- a/src/main/java/com/riscure/trs/TRSMetaDataUtils.java
+++ b/src/main/java/com/riscure/trs/TRSMetaDataUtils.java
@@ -17,9 +17,10 @@ public class TRSMetaDataUtils {
 
     /**
      * Writes the provided TRS metadata to the stream.
-     * @param fos the file output stream
+     *
+     * @param fos      the file output stream
      * @param metaData the metadata to write
-     * @throws IOException if any write error occurs
+     * @throws IOException        if any write error occurs
      * @throws TRSFormatException if the metadata contains unsupported tags
      */
     public static void writeTRSMetaData(FileOutputStream fos, TRSMetaData metaData) throws IOException, TRSFormatException {
@@ -73,16 +74,18 @@ public class TRSMetaDataUtils {
         if (length > 0x7F) {
             int lenlen = 1 + (int) (Math.log(length) / Math.log(256));
             fos.write((byte) (0x80 + lenlen));
-            for (int i = 0; i < lenlen; i++)
+            for (int i = 0; i < lenlen; i++) {
                 fos.write((byte) (length >> (i * 8)));
-        } else
+            }
+        } else {
             fos.write((byte) length);
+        }
     }
 
     /**
      * Reads the meta data of a TRS file. The {@code ByteBuffer} is assumed to be positioned at the start of the file; A
      * {@code TRSFormatException} will probably be thrown otherwise, since it cannot be parsed.
-     * 
+     *
      * @param buffer The buffer which wraps the TRS file (should be positioned at the first byte of the file)
      * @return the meta data of a TRS file
      * @throws TRSFormatException If either the file is corrupt or the reader is not positioned at the start of the file
@@ -164,21 +167,18 @@ public class TRSMetaDataUtils {
     private static String readString(ByteBuffer buffer, int length) {
         byte[] ba = new byte[length];
         buffer.get(ba);
-
         return new String(ba, StandardCharsets.UTF_8);
     }
 
     private static TraceSetParameterMap readTraceSetParameters(ByteBuffer buffer, int length) {
         byte[] ba = new byte[length];
         buffer.get(ba);
-
         return TraceSetParameterMap.deserialize(ba);
     }
 
     private static TraceParameterDefinitionMap readTraceParameterDefinitions(ByteBuffer buffer, int length) {
         byte[] ba = new byte[length];
         buffer.get(ba);
-
         return TraceParameterDefinitionMap.deserialize(ba);
     }
 }

--- a/src/main/java/com/riscure/trs/TRSMetaDataUtils.java
+++ b/src/main/java/com/riscure/trs/TRSMetaDataUtils.java
@@ -64,8 +64,9 @@ public class TRSMetaDataUtils {
     }
 
     private static void writeInt(FileOutputStream fos, int value, int length) throws IOException {
-        for (int i = 0; i < length; i++)
+        for (int i = 0; i < length; i++) {
             fos.write((byte) (value >> (i * 8)));
+        }
     }
 
     private static void writeLength(FileOutputStream fos, long length) throws IOException {
@@ -167,25 +168,17 @@ public class TRSMetaDataUtils {
         return new String(ba, StandardCharsets.UTF_8);
     }
 
-    private static TraceSetParameterMap readTraceSetParameters(ByteBuffer buffer, int length) throws TRSFormatException {
+    private static TraceSetParameterMap readTraceSetParameters(ByteBuffer buffer, int length) {
         byte[] ba = new byte[length];
         buffer.get(ba);
 
-        try {
-            return TraceSetParameterMap.deserialize(ba);
-        } catch (IOException e) {
-            throw new TRSFormatException(e);
-        }
+        return TraceSetParameterMap.deserialize(ba);
     }
 
-    private static TraceParameterDefinitionMap readTraceParameterDefinitions(ByteBuffer buffer, int length) throws TRSFormatException {
+    private static TraceParameterDefinitionMap readTraceParameterDefinitions(ByteBuffer buffer, int length) {
         byte[] ba = new byte[length];
         buffer.get(ba);
 
-        try {
-            return TraceParameterDefinitionMap.deserialize(ba);
-        } catch (IOException e) {
-            throw new TRSFormatException(e);
-        }
+        return TraceParameterDefinitionMap.deserialize(ba);
     }
 }

--- a/src/main/java/com/riscure/trs/parameter/traceset/TraceSetParameterMap.java
+++ b/src/main/java/com/riscure/trs/parameter/traceset/TraceSetParameterMap.java
@@ -18,25 +18,28 @@ import java.util.Optional;
 public class TraceSetParameterMap extends LinkedHashMap<String, TraceSetParameter> {
     private static final String KEY_NOT_FOUND = "Parameter %s was not found in the trace set.";
 
-    public byte[] serialize() throws IOException {
+    public byte[] serialize() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream dos = new DataOutputStream(baos);
-        //Write NE
-        dos.writeShort(size());
-        for (Map.Entry<String, TraceSetParameter> entry : entrySet()) {
-            byte[] nameBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
-            //Write NL
-            dos.writeShort(nameBytes.length);
-            //Write N
-            dos.write(nameBytes);
-            //Write value
-            entry.getValue().serialize(dos);
+        try (DataOutputStream dos = new DataOutputStream(baos)) {
+            //Write NE
+            dos.writeShort(size());
+            for (Map.Entry<String, TraceSetParameter> entry : entrySet()) {
+                byte[] nameBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
+                //Write NL
+                dos.writeShort(nameBytes.length);
+                //Write N
+                dos.write(nameBytes);
+                //Write value
+                entry.getValue().serialize(dos);
+            }
+            dos.flush();
+            return baos.toByteArray();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
         }
-        dos.flush();
-        return baos.toByteArray();
     }
 
-    public static TraceSetParameterMap deserialize(byte[] bytes) throws IOException {
+    public static TraceSetParameterMap deserialize(byte[] bytes) {
         TraceSetParameterMap result = new TraceSetParameterMap();
         try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
             DataInputStream dis = new DataInputStream(bais);
@@ -53,8 +56,10 @@ public class TraceSetParameterMap extends LinkedHashMap<String, TraceSetParamete
                 //Read value
                 result.put(name, TraceSetParameter.deserialize(dis));
             }
+            return result;
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
         }
-        return result;
     }
 
     public void put(String key, byte value) {


### PR DESCRIPTION
Removed caught exceptions. In general, they don't really apply (the streams should be consistent). The cases where it is not, it will be unrecoverable (file IO failed or the file formatting is wrong).