### PR TITLE
definitions can be non-empty, but still have total size 0. 

### DIFF
--- a/src/main/java/com/riscure/trs/parameter/trace/TraceParameterMap.java
+++ b/src/main/java/com/riscure/trs/parameter/trace/TraceParameterMap.java
@@ -55,7 +55,7 @@ public class TraceParameterMap extends LinkedHashMap<String, TraceParameter> {
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }
-        } else if (!definitions.isEmpty()) {
+        } else if (definitions.totalSize() != 0) {
             throw new IllegalArgumentException(EMPTY_DATA_BUT_NONEMPTY_DEFINITIONS);
         }
         return result;


### PR DESCRIPTION
This is valid, and should not throw an exception.