### PR TITLE
Adds test to check whether copy constructor makes a deep copy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,5 +118,11 @@
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/com/riscure/trs/parameter/trace/TraceParameterMapTest.java
+++ b/src/test/java/com/riscure/trs/parameter/trace/TraceParameterMapTest.java
@@ -1,0 +1,41 @@
+package com.riscure.trs.parameter.trace;
+
+import com.riscure.trs.types.ByteArrayTypeKey;
+import com.riscure.trs.types.TypedKey;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TraceParameterMapTest {
+
+    @org.junit.jupiter.api.Test
+    void modifyingOriginalAfterMakingACopyShouldNotChangeCopy() {
+        TraceParameterMap original = new TraceParameterMap();
+        byte[] ba = new byte[]{0, 1, 2, 3};
+        ByteArrayTypeKey key = new ByteArrayTypeKey("a byte array");
+        original.put(key, ba);
+
+        TraceParameterMap copyOfOriginal = new TraceParameterMap(original); // copy original
+
+        ba[0] = -1; // modify original (after creating a copy)
+
+        byte[] actual = copyOfOriginal.get(key);
+        byte[] expected = new byte[]{0, 1, 2, 3};
+        assertArrayEquals(expected, actual);
+    }
+
+    @org.junit.jupiter.api.Test
+    void modifyingCopyShouldNotChangeOriginal() {
+        TraceParameterMap original = new TraceParameterMap();
+        byte[] ba = new byte[]{0, 1, 2, 3};
+        ByteArrayTypeKey key = new ByteArrayTypeKey("a byte array");
+        original.put(key, ba);
+
+        TraceParameterMap copyOfOriginal = new TraceParameterMap(original); // copy original
+        copyOfOriginal.get(key)[0] = -1; // modify copy
+        assertArrayEquals(new byte[]{-1, 1, 2, 3}, copyOfOriginal.get(key)); // check that array in copy is changed
+
+        byte[] actual = original.get(key);
+        byte[] expected = new byte[]{0, 1, 2, 3};
+        assertArrayEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Modifying reference types only copies the reference. i.e. the copy constructor does not make a deep copy.

I can think of many cases where a deep copy is desirable. @Siebje can you make this test pass?

(Also feel free to modify this test for JUnit4 if you prefer that)