### PR TITLE
More meaningful exception messages for UnmodifiableTrace(Set)ParameterMap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,5 +119,23 @@
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.0-M1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.8.0-M1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/riscure/trs/parameter/trace/UnmodifiableTraceParameterMap.java
+++ b/src/main/java/com/riscure/trs/parameter/trace/UnmodifiableTraceParameterMap.java
@@ -12,8 +12,13 @@ import java.util.function.BiFunction;
  * This is an unmodifiable version of a trace parameter map. This should always be used for a trace read back from a file.
  */
 public class UnmodifiableTraceParameterMap extends TraceParameterMap {
-    private static final UnsupportedOperationException MODIFICATION_NOT_SUPPORTED_EXCEPTION =
-            new UnsupportedOperationException("This trace set is in read mode, and the parameters cannot be modified.");
+    private static final String UNABLE_TO_SET_PARAMETER =
+            "Unable to set parameter `%s` to `%s`: This trace set is in read mode and cannot be modified.";
+    private static final String REMOVAL_NOT_SUPPORTED_EXCEPTION =
+            "Unable to remove parameter `%s`: This trace set is in read mode and cannot be modified.";
+    private static final String MODIFICATION_NOT_SUPPORTED_EXCEPTION = "Unable to modify: This trace set is in read mode and cannot be modified.";
+
+    private static final String UNABLE_TO_ADD_ALL_OF_S_THIS_TRACE_SET_IS_IN_READ_MODE_AND_CANNOT_BE_MODIFIED = "Unable to add all of `%s` : This trace set is in read mode and cannot be modified.";
 
     private UnmodifiableTraceParameterMap(TraceParameterMap delegate) {
         super.putAll(delegate.copy());
@@ -25,22 +30,38 @@ public class UnmodifiableTraceParameterMap extends TraceParameterMap {
 
     @Override
     public TraceParameter put(String key, TraceParameter value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.toString()
+                )
+        );
     }
 
     @Override
     public TraceParameter remove(Object key) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(REMOVAL_NOT_SUPPORTED_EXCEPTION,
+                        key
+                )
+        );
     }
 
     @Override
     public void putAll(Map<? extends String, ? extends TraceParameter> m) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(
+                        UNABLE_TO_ADD_ALL_OF_S_THIS_TRACE_SET_IS_IN_READ_MODE_AND_CANNOT_BE_MODIFIED,
+                        m.toString()
+                )
+        );
     }
 
     @Override
     public void clear() {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                MODIFICATION_NOT_SUPPORTED_EXCEPTION
+        );
     }
 
     @Override
@@ -60,31 +81,51 @@ public class UnmodifiableTraceParameterMap extends TraceParameterMap {
 
     @Override
     public void replaceAll(BiFunction<? super String, ? super TraceParameter, ? extends TraceParameter> function) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(MODIFICATION_NOT_SUPPORTED_EXCEPTION);
     }
 
     @Override
     public TraceParameter putIfAbsent(String key, TraceParameter value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.toString()
+                )
+        );
     }
 
     @Override
     public boolean remove(Object key, Object value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(
+                        REMOVAL_NOT_SUPPORTED_EXCEPTION,
+                        key
+                )
+        );
     }
 
     @Override
     public boolean replace(String key, TraceParameter oldValue, TraceParameter newValue) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        newValue.toString()
+                )
+        );
     }
 
     @Override
     public TraceParameter replace(String key, TraceParameter value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.toString()
+                )
+        );
     }
 
     @Override
     public TraceParameter merge(String key, TraceParameter value, BiFunction<? super TraceParameter, ? super TraceParameter, ? extends TraceParameter> remappingFunction) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(MODIFICATION_NOT_SUPPORTED_EXCEPTION);
     }
 }

--- a/src/main/java/com/riscure/trs/parameter/trace/definition/UnmodifiableTraceParameterDefinitionMap.java
+++ b/src/main/java/com/riscure/trs/parameter/trace/definition/UnmodifiableTraceParameterDefinitionMap.java
@@ -14,8 +14,14 @@ import java.util.function.BiFunction;
  * This map is read from the file, and is therefore unmodifiable.
  */
 public class UnmodifiableTraceParameterDefinitionMap extends TraceParameterDefinitionMap {
-    private static final UnsupportedOperationException MODIFICATION_NOT_SUPPORTED_EXCEPTION =
-            new UnsupportedOperationException("This trace set is in read mode, and the parameters cannot be modified.");
+    private static final String UNABLE_TO_SET_PARAMETER =
+            "Unable to set parameter `%s` to `%s`: This trace set is in read mode and cannot be modified.";
+    private static final String REMOVAL_NOT_SUPPORTED_EXCEPTION =
+            "Unable to remove parameter `%s`: This trace set is in read mode and cannot be modified.";
+    private static final String MODIFICATION_NOT_SUPPORTED_EXCEPTION = "Unable to modify: This trace set is in read mode and cannot be modified.";
+
+    private static final String UNABLE_TO_ADD_ALL_OF_S_THIS_TRACE_SET_IS_IN_READ_MODE_AND_CANNOT_BE_MODIFIED = "Unable to add all of `%s` : This trace set is in read mode and cannot be modified.";
+
 
     private UnmodifiableTraceParameterDefinitionMap(TraceParameterDefinitionMap delegate) {
         super.putAll(delegate.copy());
@@ -27,22 +33,38 @@ public class UnmodifiableTraceParameterDefinitionMap extends TraceParameterDefin
 
     @Override
     public TraceParameterDefinition<TraceParameter> put(String key, TraceParameterDefinition<TraceParameter> value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.toString()
+                )
+        );
     }
 
     @Override
     public TraceParameterDefinition<TraceParameter> remove(Object key) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(REMOVAL_NOT_SUPPORTED_EXCEPTION,
+                        key
+                )
+        );
     }
 
     @Override
     public void putAll(Map<? extends String, ? extends TraceParameterDefinition<TraceParameter>> m) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(
+                        UNABLE_TO_ADD_ALL_OF_S_THIS_TRACE_SET_IS_IN_READ_MODE_AND_CANNOT_BE_MODIFIED,
+                        m.toString()
+                )
+        );
     }
 
     @Override
     public void clear() {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                MODIFICATION_NOT_SUPPORTED_EXCEPTION
+        );
     }
 
     @Override
@@ -62,31 +84,51 @@ public class UnmodifiableTraceParameterDefinitionMap extends TraceParameterDefin
 
     @Override
     public void replaceAll(BiFunction<? super String, ? super TraceParameterDefinition<TraceParameter>, ? extends TraceParameterDefinition<TraceParameter>> function) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(MODIFICATION_NOT_SUPPORTED_EXCEPTION);
     }
 
     @Override
     public TraceParameterDefinition<TraceParameter> putIfAbsent(String key, TraceParameterDefinition<TraceParameter> value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.toString()
+                )
+        );
     }
 
     @Override
     public boolean remove(Object key, Object value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(
+                        REMOVAL_NOT_SUPPORTED_EXCEPTION,
+                        key
+                )
+        );
     }
 
     @Override
     public boolean replace(String key, TraceParameterDefinition<TraceParameter> oldValue, TraceParameterDefinition<TraceParameter> newValue) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        newValue.toString()
+                )
+        );
     }
 
     @Override
     public TraceParameterDefinition<TraceParameter> replace(String key, TraceParameterDefinition<TraceParameter> value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.toString()
+                )
+        );
     }
 
     @Override
     public TraceParameterDefinition<TraceParameter> merge(String key, TraceParameterDefinition<TraceParameter> value, BiFunction<? super TraceParameterDefinition<TraceParameter>, ? super TraceParameterDefinition<TraceParameter>, ? extends TraceParameterDefinition<TraceParameter>> remappingFunction) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(MODIFICATION_NOT_SUPPORTED_EXCEPTION);
     }
 }

--- a/src/main/java/com/riscure/trs/parameter/traceset/TraceSetParameter.java
+++ b/src/main/java/com/riscure/trs/parameter/traceset/TraceSetParameter.java
@@ -11,6 +11,11 @@ import java.util.Objects;
 public class TraceSetParameter {
     private final TraceParameter value;
 
+    @Override
+    public String toString() {
+        return this.value.toString();
+    }
+
     public TraceSetParameter(TraceParameter instance) {
         this.value = instance;
     }

--- a/src/main/java/com/riscure/trs/parameter/traceset/UnmodifiableTraceSetParameterMap.java
+++ b/src/main/java/com/riscure/trs/parameter/traceset/UnmodifiableTraceSetParameterMap.java
@@ -9,8 +9,13 @@ import java.util.function.BiFunction;
  * This map is read from the file, and is therefore unmodifiable.
  */
 public class UnmodifiableTraceSetParameterMap extends TraceSetParameterMap {
-    private static final UnsupportedOperationException MODIFICATION_NOT_SUPPORTED_EXCEPTION =
-            new UnsupportedOperationException("This trace set is in read mode, and the parameters cannot be modified.");
+    private static final String UNABLE_TO_SET_PARAMETER =
+            "Unable to set parameter `%s` to `%s`: This trace set is in read mode and cannot be modified.";
+    private static final String REMOVAL_NOT_SUPPORTED_EXCEPTION =
+            "Unable to remove parameter `%s`: This trace set is in read mode and cannot be modified.";
+    private static final String MODIFICATION_NOT_SUPPORTED_EXCEPTION = "Unable to modify: This trace set is in read mode and cannot be modified.";
+
+    private static final String UNABLE_TO_ADD_ALL_OF_S_THIS_TRACE_SET_IS_IN_READ_MODE_AND_CANNOT_BE_MODIFIED = "Unable to add all of `%s` : This trace set is in read mode and cannot be modified.";
 
     private UnmodifiableTraceSetParameterMap(TraceSetParameterMap delegate) {
         super.putAll(delegate.copy());
@@ -22,22 +27,38 @@ public class UnmodifiableTraceSetParameterMap extends TraceSetParameterMap {
 
     @Override
     public TraceSetParameter put(String key, TraceSetParameter value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.getValue()
+                )
+        );
     }
 
     @Override
     public TraceSetParameter remove(Object key) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(REMOVAL_NOT_SUPPORTED_EXCEPTION,
+                        key
+                )
+        );
     }
 
     @Override
     public void putAll(Map<? extends String, ? extends TraceSetParameter> m) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(
+                        UNABLE_TO_ADD_ALL_OF_S_THIS_TRACE_SET_IS_IN_READ_MODE_AND_CANNOT_BE_MODIFIED,
+                        m.toString()
+                )
+        );
     }
 
     @Override
     public void clear() {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                MODIFICATION_NOT_SUPPORTED_EXCEPTION
+        );
     }
 
     @Override
@@ -57,31 +78,51 @@ public class UnmodifiableTraceSetParameterMap extends TraceSetParameterMap {
 
     @Override
     public void replaceAll(BiFunction<? super String, ? super TraceSetParameter, ? extends TraceSetParameter> function) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(MODIFICATION_NOT_SUPPORTED_EXCEPTION);
     }
 
     @Override
     public TraceSetParameter putIfAbsent(String key, TraceSetParameter value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.toString()
+                )
+        );
     }
 
     @Override
     public boolean remove(Object key, Object value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(
+                        REMOVAL_NOT_SUPPORTED_EXCEPTION,
+                        key
+                )
+        );
     }
 
     @Override
     public boolean replace(String key, TraceSetParameter oldValue, TraceSetParameter newValue) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        newValue.toString()
+                )
+        );
     }
 
     @Override
     public TraceSetParameter replace(String key, TraceSetParameter value) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(
+                String.format(UNABLE_TO_SET_PARAMETER,
+                        key,
+                        value.toString()
+                )
+        );
     }
 
     @Override
     public TraceSetParameter merge(String key, TraceSetParameter value, BiFunction<? super TraceSetParameter, ? super TraceSetParameter, ? extends TraceSetParameter> remappingFunction) {
-        throw MODIFICATION_NOT_SUPPORTED_EXCEPTION;
+        throw new UnsupportedOperationException(MODIFICATION_NOT_SUPPORTED_EXCEPTION);
     }
 }

--- a/src/test/java/TestTraceSet.java
+++ b/src/test/java/TestTraceSet.java
@@ -8,7 +8,6 @@ import com.riscure.trs.enums.TRSTag;
 import com.riscure.trs.parameter.TraceParameter;
 import com.riscure.trs.parameter.primitive.ByteArrayParameter;
 import com.riscure.trs.parameter.trace.TraceParameterMap;
-import com.riscure.trs.parameter.trace.UnmodifiableTraceParameterMap;
 import com.riscure.trs.parameter.trace.definition.TraceParameterDefinition;
 import com.riscure.trs.parameter.trace.definition.TraceParameterDefinitionMap;
 import com.riscure.trs.parameter.traceset.TraceSetParameterMap;
@@ -529,21 +528,6 @@ public class TestTraceSet {
 
         assertThrows(ClassCastException.class, () -> tpm.containsKey(typedKey));
         assertThrows(ClassCastException.class, () -> tspm.containsKey(typedKey));
-    }
-
-    /**
-     * This test ensure that the underlying map of an unmodifiable map cannot change the map itself
-     */
-    @Test
-    public void testUnmodifiable() {
-        byte[] ba = {1, 2, 3, 4, 5};
-        ByteArrayParameter bap = new ByteArrayParameter(ba);
-        TraceParameterMap tpm = new TraceParameterMap();
-        tpm.put("BA", bap);
-        TraceParameterMap copy = UnmodifiableTraceParameterMap.of(tpm);
-        ba[1] = 6;
-        byte[] baCopy = (byte[]) copy.get("BA").getValue();
-        assertFalse("Arrays should not be equal, but they are", Arrays.equals(baCopy, ba));
     }
 
     /**

--- a/src/test/java/com/riscure/trs/parameter/trace/UnmodifiableTraceParameterMapTest.java
+++ b/src/test/java/com/riscure/trs/parameter/trace/UnmodifiableTraceParameterMapTest.java
@@ -1,0 +1,184 @@
+package com.riscure.trs.parameter.trace;
+
+import com.riscure.trs.parameter.primitive.ByteArrayParameter;
+import com.riscure.trs.parameter.primitive.IntArrayParameter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class UnmodifiableTraceParameterMapTest {
+    private TraceParameterMap immutable;
+
+    @BeforeEach
+    public void setup() {
+        TraceParameterMap mutable = new TraceParameterMap();
+        mutable.put("FOO", 1);
+
+        immutable = UnmodifiableTraceParameterMap.of(mutable);
+    }
+
+    /**
+     * This test ensure that the underlying map of an unmodifiable map cannot change the map itself
+     */
+    @Test
+    public void testUnmodifiable() {
+        byte[] ba = {1, 2, 3, 4, 5};
+        ByteArrayParameter bap = new ByteArrayParameter(ba);
+        TraceParameterMap tpm = new TraceParameterMap();
+        tpm.put("BA", bap);
+        TraceParameterMap copy = UnmodifiableTraceParameterMap.of(tpm);
+        ba[1] = 6;
+        byte[] baCopy = (byte[]) copy.get("BA").getValue();
+        Assertions.assertFalse(Arrays.equals(baCopy, ba), "Arrays should not be equal, but they are");
+    }
+
+
+    @Test
+    public void put() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.put("BLA", 2)
+        );
+
+        String expectedMessage = "Unable to set parameter `BLA` to `[2]`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void remove() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.remove("FOO")
+        );
+
+        String expectedMessage = "Unable to remove parameter `FOO`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void putAll() {
+        TraceParameterMap source = new TraceParameterMap();
+        source.put("BEEP", 5);
+        source.put("BOOP", 7);
+
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.putAll(source)
+        );
+
+        String expectedMessage = "Unable to add all of `{BEEP=[5], BOOP=[7]}` : This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void clear() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.clear()
+        );
+
+        String expectedMessage = "Unable to modify: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+
+    @Test
+    public void replaceAll() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.replaceAll(
+                        (key, oldValue)
+                                -> new IntArrayParameter(new int[]{1})
+                )
+        );
+
+        String expectedMessage = "Unable to modify: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void putIfAbsent() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.putIfAbsent("BLA", new IntArrayParameter(new int[]{-1}))
+        );
+
+        String expectedMessage = "Unable to set parameter `BLA` to `[-1]`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testRemove() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.remove("BLA", "MEH")
+        );
+
+        String expectedMessage = "Unable to remove parameter `BLA`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void replace() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.replace("FOO", new IntArrayParameter(new int[]{1}), new IntArrayParameter(new int[]{-1}))
+        );
+
+        String expectedMessage = "Unable to set parameter `FOO` to `[-1]`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testReplace() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.replace("FOO", new IntArrayParameter(new int[]{-1}))
+        );
+
+        String expectedMessage = "Unable to set parameter `FOO` to `[-1]`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void merge() {
+
+
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.merge(
+                        "BLA",
+                        new IntArrayParameter(new int[]{77}),
+                        (traceParameter, traceParameter2) -> new IntArrayParameter(new int[]{55})
+                )
+        );
+
+        String expectedMessage = "Unable to modify: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+}

--- a/src/test/java/com/riscure/trs/parameter/traceset/UnmodifiableTraceSetParameterMapTest.java
+++ b/src/test/java/com/riscure/trs/parameter/traceset/UnmodifiableTraceSetParameterMapTest.java
@@ -1,0 +1,165 @@
+package com.riscure.trs.parameter.traceset;
+
+import com.riscure.trs.parameter.primitive.IntArrayParameter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UnmodifiableTraceSetParameterMapTest {
+    private TraceSetParameterMap immutable;
+
+    @BeforeEach
+    public void setup() {
+        TraceSetParameterMap mutable = new TraceSetParameterMap();
+        mutable.put("FOO", 1);
+
+        immutable = UnmodifiableTraceSetParameterMap.of(mutable);
+    }
+
+
+    @Test
+    public void put() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.put("BLA", 2)
+        );
+
+        String expectedMessage = "Unable to set parameter `BLA` to `[2]`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void remove() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.remove("FOO")
+        );
+
+        String expectedMessage = "Unable to remove parameter `FOO`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void putAll() {
+        TraceSetParameterMap source = new TraceSetParameterMap();
+        source.put("BEEP", 5);
+        source.put("BOOP", 7);
+
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.putAll(source)
+        );
+
+        String expectedMessage = "Unable to add all of `{BEEP=[5], BOOP=[7]}` : This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void clear() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.clear()
+        );
+
+        String expectedMessage = "Unable to modify: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+
+    @Test
+    public void replaceAll() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.replaceAll(
+                        (key, oldValue)
+                                -> new TraceSetParameter(new IntArrayParameter(new int[]{-1}))
+                )
+        );
+
+        String expectedMessage = "Unable to modify: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void putIfAbsent() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.putIfAbsent("BLA", new TraceSetParameter(new IntArrayParameter(new int[]{-1})))
+        );
+
+        String expectedMessage = "Unable to set parameter `BLA` to `[-1]`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testRemove() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.remove("BLA", "MEH")
+        );
+
+        String expectedMessage = "Unable to remove parameter `BLA`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void replace() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.replace("FOO", new TraceSetParameter(new IntArrayParameter(new int[]{1})), new TraceSetParameter(new IntArrayParameter(new int[]{-1})))
+        );
+
+        String expectedMessage = "Unable to set parameter `FOO` to `[-1]`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testReplace() {
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.replace("FOO", new TraceSetParameter(new IntArrayParameter(new int[]{-1})))
+        );
+
+        String expectedMessage = "Unable to set parameter `FOO` to `[-1]`: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void merge() {
+
+
+        Exception e = assertThrows(
+                UnsupportedOperationException.class,
+                () -> immutable.merge(
+                        "BLA",
+                        new TraceSetParameter(new IntArrayParameter(new int[]{77})),
+                        (traceParameter, traceParameter2) -> new TraceSetParameter(new IntArrayParameter(new int[]{55}))
+                )
+        );
+
+        String expectedMessage = "Unable to modify: This trace set is in read mode and cannot be modified.";
+        String actualMessage = e.getMessage();
+
+        Assertions.assertTrue(actualMessage.contains(expectedMessage));
+    }
+}


### PR DESCRIPTION
This includes the name and/or value of the Trace(Set)Parameter that caused the `UnsupportedOperationException`. Motivation was that this makes it easier to find the code segment that caused the exception.