### PR TITLE
Added check to allow empty Strings at the end of an input stream.

### DIFF
--- a/src/main/java/com/riscure/trs/parameter/primitive/StringParameter.java
+++ b/src/main/java/com/riscure/trs/parameter/primitive/StringParameter.java
@@ -28,7 +28,8 @@ public class StringParameter extends TraceParameter {
     public static StringParameter deserialize(DataInputStream dis, int length) throws IOException {
         byte[] bytes = new byte[length];
         int bytesRead = dis.read(bytes);
-        if (bytesRead != length) throw new IOException(String.format(INVALID_LENGTH, length, bytesRead));
+        boolean emptyReadAtEOF = (bytesRead == -1) && (length == 0);
+        if (bytesRead != length && !emptyReadAtEOF) throw new IOException(String.format(INVALID_LENGTH, length, bytesRead));
         return new StringParameter(new String(bytes, StandardCharsets.UTF_8));
     }
 


### PR DESCRIPTION
This fixes a bug were a traceset with an empty String-type traceset parameter at the end of its TraceSet parameter map would be seen as a corrupted traceset.