### PR TITLE
Bugfix/61 0 length data

### DIFF
--- a/src/main/java/com/riscure/trs/TraceSet.java
+++ b/src/main/java/com/riscure/trs/TraceSet.java
@@ -161,7 +161,9 @@ public class TraceSet implements AutoCloseable {
                 //legacy mode
                 byte[] data = readData();
                 traceParameterMap = new TraceParameterMap();
-                traceParameterMap.put("LEGACY_DATA", data);
+                if (data.length > 0) {
+                    traceParameterMap.put("LEGACY_DATA", data);
+                }
             }
 
             float[] samples = readSamples();

--- a/src/test/java/TestTraceSet.java
+++ b/src/test/java/TestTraceSet.java
@@ -647,4 +647,20 @@ public class TestTraceSet {
                             .getMessage().startsWith("Requested trace index"));
         }
     }
+
+    /**
+     * Test to reproduce Github issue #61: Reading a legacy trace with a 0-length data field
+     */
+    @Test
+    void test61ReadLegacyTraceWithoutData() throws IOException, TRSFormatException {
+        Path filePath = tempDir.resolve("test_issue_61.trs");
+        TRSMetaData metaData = new TRSMetaData();
+        metaData.put(TRSTag.TRS_VERSION, 1);
+        try (TraceSet ts = TraceSet.create(filePath.toString(), metaData)) {
+            ts.add(new Trace(new float[]{}));
+        }
+        try (TraceSet ts = TraceSet.open(filePath.toString())) {
+            assertDoesNotThrow(() -> ts.get(0));
+        }
+    }
 }


### PR DESCRIPTION
Addressed issue #61: Added length check when reading legacy traces